### PR TITLE
Add a new property for the episode bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This file has the following possible lines:
   - hook: This must be an XPath search string to identify the value from the script for this field
   - list: false
 - episodeScriptHooks: This is a map (`key: value`) of different types of episodes (podcast, pills, etc.)
+- episodeBucket: This is the bucket name where all the published tracks are stored
   The program uses the key as a pattern match on the track name, along with the number, to identify the script.
   The `default` key must be present.
 
@@ -60,4 +61,5 @@ intro: https://my.podcast.com/media/intro.mp3
 master: https://my.podcast.com/masters/episode-1.master.mp3
 pubDate: 2021-08-31T20:52:50.658906773+02:00
 trackNo: 1
+bucket: mypodcast-episodes
 ```

--- a/pkg/epidator/epidator_test.go
+++ b/pkg/epidator/epidator_test.go
@@ -65,6 +65,7 @@ func TestGetEpisodeDetails(t *testing.T) {
 				"summary": "In this episode I'll talk about my podcast.",
 				"title":   "Podcast 1 - My Podcast",
 				"trackNo": 1,
+				"bucket":  "mypodcast-episodes",
 			},
 		},
 		{
@@ -97,6 +98,7 @@ func TestGetEpisodeDetails(t *testing.T) {
 				"summary": "In this collaboration, I'm hosting my friend's episode.",
 				"title":   "Collaboration 1 - My friend's episode",
 				"trackNo": 2,
+				"bucket":  "mypodcast-episodes",
 			},
 		},
 	}

--- a/pkg/epidator/podcast.go
+++ b/pkg/epidator/podcast.go
@@ -198,13 +198,13 @@ func (p *Podcast) extractPropertiesFromScript() {
 	}
 }
 
-func (pd *Podcast) extractPropertiesFromFeed() error {
-	trackNo, err := pd.trackNo()
+func (p *Podcast) extractPropertiesFromFeed() error {
+	trackNo, err := p.trackNo()
 	if err != nil {
 		return err
 	}
 
-	pd.details["trackNo"] = trackNo
+	p.details["trackNo"] = trackNo
 	return nil
 }
 

--- a/pkg/epidator/podcast.go
+++ b/pkg/epidator/podcast.go
@@ -71,10 +71,11 @@ type Podcast struct {
 	FeedURL          string `yaml:"feedURL"`
 	MasterURLPattern string `yaml:"masterURLPattern"`
 	DirectFields     struct {
-		Cover    string `yaml:"cover"`
-		Artist   string `yaml:"artist"`
-		Album    string `yaml:"album"`
-		IntroURL string `yaml:"introURL"`
+		Cover         string `yaml:"cover"`
+		Artist        string `yaml:"artist"`
+		Album         string `yaml:"album"`
+		IntroURL      string `yaml:"introURL"`
+		EpisodeBucket string `yaml:"episodeBucket"`
 	} `yaml:"directFields"`
 	ScriptFieldHooks []struct {
 		Name      string `yaml:"name"`
@@ -213,6 +214,7 @@ func (p *Podcast) extractDirectProperties() {
 	p.details["artist"] = p.DirectFields.Artist
 	p.details["album"] = p.DirectFields.Album
 	p.details["intro"] = p.DirectFields.IntroURL
+	p.details["bucket"] = p.DirectFields.EpisodeBucket
 }
 
 func (p *Podcast) extractProperties() (err error) {

--- a/podcast.yaml
+++ b/podcast.yaml
@@ -5,6 +5,7 @@ directFields:
   cover: https://my.podcast.com/media/cover.png
   artist: Me
   album: My Podcast
+  episodeBucket: mypodcast-episodes
 scriptFieldHooks:
 - name: title
   hook: /html/body/p/span[contains(@style,"font-size:24pt;")]


### PR DESCRIPTION
This field is used later in the publishing process to identify the 
destination bucket of the edited audio track.

This change includes a small fix on a golint complain.