### PR TITLE
Add more test jobs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -95,6 +95,10 @@ jobs:
         run: |
           go install github.com/gordonklaus/ineffassign@latest
       -
+        name: Download dependencies to local
+        run : |
+          go mod download
+      -
         name: Check ineffectual assignments
         run: |
           ineffassign ./...

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -121,6 +121,29 @@ jobs:
         name: Check spelling
         run: |
           misspell -error .
+  staticcheck:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.16'
+      -
+        name: Install staticcheck
+        run: |
+          go get -u honnef.co/go/tools/cmd/staticcheck@latest
+      -
+        name: Download dependencies to local
+        run : |
+          go mod download
+      -
+        name: Run staticcheck
+        run: |
+          staticcheck ./...
   check-license:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,6 +33,11 @@ jobs:
         name: Checkout
         uses: actions/checkout@v2
       -
+        name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.16'
+      -
         name: Check code smells
         run: |
           go vet ./...


### PR DESCRIPTION
This includes the following:
* Ensure go last version for go vet execution,
* ensure ineffassign dependencies are installed, and
* add staticheck linter: This linter includes some interesting checks other linters don't.